### PR TITLE
Fix URL in redirect

### DIFF
--- a/functions/src/getGitHubOAuthAccessToken.js
+++ b/functions/src/getGitHubOAuthAccessToken.js
@@ -37,5 +37,5 @@ const getGitHubOAuthAccessToken = (clientId, clientSecret, code) => {
 const redirect = (callback, url) => callback(null, { body: '', statusCode: 302, headers: { location: url } });
 
 export const handler = (event, context, callback) => getGitHubOAuthAccessToken(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, event.queryStringParameters.code)
-  .then(accessToken => redirect(callback, `${FRONTEND_URL}/oauth/success#${qs.stringify({ access_token: accessToken })}`))
+  .then(accessToken => redirect(callback, `${FRONTEND_URL}/oauth/success?${qs.stringify({ access_token: accessToken })}`))
   .catch(e => redirect(callback, `${FRONTEND_URL}/oauth/failure?${qs.stringify({ error: e.message })}`));


### PR DESCRIPTION
We're generating URLs like `https://app.branch-bookkeeper.com/oauth/success?code=[...]#access_token=[...]`.
Then when parsing the URL in https://github.com/branch-bookkeeper/pina/blob/439c49b72124f014e864a4b118b158908c06c6d4/src/pages/OAuthSuccess.js#L33 we fail and user is not logged in